### PR TITLE
Propagate SRFI procedure name changes to implementation

### DIFF
--- a/srfi/175.scm
+++ b/srfi/175.scm
@@ -114,15 +114,15 @@
       (integer->char (ascii-downcase (char->integer x)))
       (or (ascii-upper-case-value x #x61 26) x)))
 
-(define (ascii-control->display x)
+(define (ascii-control->graphic x)
   (if (char? x)
-      (char->int->char ascii-control->display x)
+      (char->int->char ascii-control->graphic x)
       (or (and (<= 0 x #x1f) (+ x #x40))
           (and (= x #x7f) #x3f))))
 
-(define (ascii-display->control x)
+(define (ascii-graphic->control x)
   (if (char? x)
-      (char->int->char ascii-display->control x)
+      (char->int->char ascii-graphic->control x)
       (or (and (<= #x40 x #x5f) (- x #x40))
           (and (= x #x3f) #x7f))))
 

--- a/srfi/175.sld
+++ b/srfi/175.sld
@@ -25,8 +25,8 @@
           ascii-nth-lower-case
           ascii-upcase
           ascii-downcase
-          ascii-control->display
-          ascii-display->control
+          ascii-control->graphic
+          ascii-graphic->control
           ascii-mirror-bracket
 
           ascii-ci=?

--- a/srfi/175.sls
+++ b/srfi/175.sls
@@ -25,8 +25,8 @@
                  ascii-nth-lower-case
                  ascii-upcase
                  ascii-downcase
-                 ascii-control->display
-                 ascii-display->control
+                 ascii-control->graphic
+                 ascii-graphic->control
                  ascii-mirror-bracket
                  ascii-ci=?
                  ascii-ci<?
@@ -111,13 +111,13 @@
            (if (char? x)
                (integer->char (ascii-downcase (char->integer x)))
                (or (ascii-upper-case-value x 97 26) x)))
-         (define (ascii-control->display x)
+         (define (ascii-control->graphic x)
            (if (char? x)
-               (char->int->char ascii-control->display x)
+               (char->int->char ascii-control->graphic x)
                (or (and (fx<=? 0 x 31) (fx+ x 64)) (and (fx=? x 127) 63))))
-         (define (ascii-display->control x)
+         (define (ascii-graphic->control x)
            (if (char? x)
-               (char->int->char ascii-display->control x)
+               (char->int->char ascii-graphic->control x)
                (or (and (fx<=? 64 x 95) (fx- x 64)) (and (fx=? x 63) 127))))
          (define (ascii-mirror-bracket char)
            (if (integer? char)

--- a/srfi/srfi-175.sls
+++ b/srfi/srfi-175.sls
@@ -25,8 +25,8 @@
                  ascii-nth-lower-case
                  ascii-upcase
                  ascii-downcase
-                 ascii-control->display
-                 ascii-display->control
+                 ascii-control->graphic
+                 ascii-graphic->control
                  ascii-mirror-bracket
                  ascii-ci=?
                  ascii-ci<?
@@ -111,13 +111,13 @@
            (if (char? x)
                (integer->char (ascii-downcase (char->integer x)))
                (or (ascii-upper-case-value x 97 26) x)))
-         (define (ascii-control->display x)
+         (define (ascii-control->graphic x)
            (if (char? x)
-               (char->int->char ascii-control->display x)
+               (char->int->char ascii-control->graphic x)
                (or (and (fx<=? 0 x 31) (fx+ x 64)) (and (fx=? x 127) 63))))
-         (define (ascii-display->control x)
+         (define (ascii-graphic->control x)
            (if (char? x)
-               (char->int->char ascii-display->control x)
+               (char->int->char ascii-graphic->control x)
                (or (and (fx<=? 64 x 95) (fx- x 64)) (and (fx=? x 63) 127))))
          (define (ascii-mirror-bracket char)
            (if (integer? char)

--- a/srfi/tests.scm
+++ b/srfi/tests.scm
@@ -89,11 +89,11 @@
            (want #f (ascii-non-control? cc))
            (want #f (ascii-other-graphic? cc))
            (want cc
-                 (ascii-display->control
-                  (ascii-control->display cc)))
+                 (ascii-graphic->control
+                  (ascii-control->graphic cc)))
            (want (integer->char cc)
-                 (ascii-display->control
-                  (ascii-control->display (integer->char cc)))))
+                 (ascii-graphic->control
+                  (ascii-control->graphic (integer->char cc)))))
           ((member cc '(#\( #\) #\[ #\] #\{ #\} #\< #\>))
            (want cc (ascii-mirror-bracket (ascii-mirror-bracket cc)))))
     (loop (+ cc 1))))

--- a/srfi/tests.sps
+++ b/srfi/tests.sps
@@ -80,11 +80,11 @@
      ((ascii-control? cc) (want #f (ascii-non-control? cc))
                           (want #f (ascii-other-graphic? cc))
                           (want cc
-                                (ascii-display->control
-                                 (ascii-control->display cc)))
+                                (ascii-graphic->control
+                                 (ascii-control->graphic cc)))
                           (want (integer->char cc)
-                                (ascii-display->control
-                                 (ascii-control->display (integer->char cc)))))
+                                (ascii-graphic->control
+                                 (ascii-control->graphic (integer->char cc)))))
      ((member cc '(#\( #\) #\[ #\] #\{ #\} #\< #\>))
       (want cc (ascii-mirror-bracket (ascii-mirror-bracket cc)))))
     (loop (fx+ cc 1))))


### PR DESCRIPTION
One last change to the implementation. Changes the names of two procedures to match the latest draft of the SRFI. I forgot to update these when sending draft 5.